### PR TITLE
Allow launching debugger despite focused file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
-.vscode/
+.vscode/*
+!.vscode/launch.json
 
 */tags
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Murder Mystery",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/murder/main.py",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "python": "${command:python.interpreterPath}"
+    }
+  ]
+}


### PR DESCRIPTION
This configuration will always run the main.py file regardless of which
file is currently open, and will respect your breakpoints in any file.

https://code.visualstudio.com/docs/python/debugging

Specific configuration options are documented here: https://code.visualstudio.com/docs/python/debugging#_set-configuration-options

![launch](https://media3.giphy.com/media/l1J3o5to1feuXRiuI/giphy.gif?cid=d1fd59ab91o05omd2qel8tcs2iicyn4m2km0z6mcrglh52qz&ep=v1_gifs_search&rid=giphy.gif&ct=g)